### PR TITLE
Add module declaration with supabase as a type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,3 +5,9 @@ declare module '@nuxt/types' {
     $supabase: SupabaseClient
   }
 }
+
+declare module 'vuex' {
+  interface Store<S> {
+    $supabase: SupabaseClient
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
This simply adds a supabase type definition to the vuex store interface. When the SupabaseClient is injected, it is also made available to the store context i.e. actions, mutations but my editor doesn't know that.

## What is the current behavior?
Red squigly lines as saying supabase is unknown or not defined when used inside of either an action or mutation

Please link any relevant issues here.

## What is the new behavior?
No type error, and autocomplete, thanks to typescript

Feel free to include screenshots if it includes visual changes.
![image](https://user-images.githubusercontent.com/48126337/123346350-5ed83c80-d558-11eb-9926-88858c6b999f.png)


## Additional context

Add any other context or screenshots.
