### PR TITLE
Cleanup typescript usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ modules: [
   }]
 ],
 ```
+### TypeScript
+Add the package to your tsconfig.json to make typescript aware of the additional types to the the nuxt context
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "@nuxt/types",
+      "nuxt-supabase"
+    ]
+  }
+}
+```
 
 ## Usage
 
@@ -30,14 +42,15 @@ You can then use supabase within your Nuxt context, or Vue components.
 ```vue
 <script>
 export default {
-  asyncData({ $supabase }) {
+  async asyncData({ $supabase }) {
     return {
       events: await $supabase.from("events").select("*");
     }
   }
 }
 </script>
-
+```
+```vue
 <script>
 export default {
   data() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,11 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 
+declare module 'vue/types/vue' {
+  interface Vue {
+    $supabase: SupabaseClient
+  }
+}
+
 declare module '@nuxt/types' {
   interface Context {
     $supabase: SupabaseClient

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/scottrobertson/nuxt-supabase#readme",
   "dependencies": {
+    "@supabase/supabase-js": "^1.21.1",
     "@vue/composition-api": "^1.0.4",
     "vue-supabase": "^2.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     cross-fetch "^3.0.6"
 
+"@supabase/gotrue-js@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-1.17.0.tgz#0ff46f844ddd124543d2769da8eda58ab479b49b"
+  integrity sha512-c+GSSoW+PIT3/r7TnBdc4gPjtWDutO/2ROafSKUFl39Pb8aHIUbUvzK9sjuedaaLKH7bV8VefuRy2L8c0BUAzg==
+  dependencies:
+    cross-fetch "^3.0.6"
+
 "@supabase/postgrest-js@^0.33.0":
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-0.33.0.tgz#36e0bfd0f79a0fa01a4bb7c7881ee463fd7d60a8"
@@ -24,12 +31,30 @@
     "@types/websocket" "^1.0.3"
     websocket "^1.0.34"
 
+"@supabase/realtime-js@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-1.1.2.tgz#6bdb0411df292c9d6a2d1a5a4e11c2673aec5f76"
+  integrity sha512-YNFiWF0T9+IuZZgswzHbGb7/O1eWJSwXvi0WlbARHTIcYBu4GQQXBdVWdFdG4bTLMS3L4K2qHpvMP91QYSasMw==
+  dependencies:
+    "@types/websocket" "^1.0.3"
+    websocket "^1.0.34"
+
 "@supabase/storage-js@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-1.4.0.tgz#0692782ccaf10df27d539d9349031ed87c7ec426"
   integrity sha512-7+SGyXOgdhtz8qHzXo64HiS66PT/y4F8YFNMtXqYOu1LjHh0YwtOgpPLDA8obiSsNVwZiKwpgBJkz4LHG1YvRQ==
   dependencies:
     cross-fetch "^3.1.0"
+
+"@supabase/supabase-js@^1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-1.21.1.tgz#013ce0104e8ebfb3290dd9734373550776c93a27"
+  integrity sha512-hHDV9XA/H9ZFxflqo+1/uUg0bY6xlVePj0acG+kDLcrONWPcQ4zDAqprZONU99MDxeH2cTFaJEbxvF8eNAEMDw==
+  dependencies:
+    "@supabase/gotrue-js" "^1.17.0"
+    "@supabase/postgrest-js" "^0.33.0"
+    "@supabase/realtime-js" "^1.1.2"
+    "@supabase/storage-js" "^1.4.0"
 
 "@supabase/supabase-js@^1.4.2":
   version "1.20.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fixes missing type from the vue instance exposed to nuxt
- Adds details into setting up the module for TypeScript usage

## What is the current behavior?
- When using the options api, `$supabase` is not picked up by typescript
- https://github.com/supabase/nuxt-supabase/issues/8

## What is the new behavior?
![image](https://user-images.githubusercontent.com/48126337/129456248-33db0ebe-da86-4467-9e43-05fabf256876.png)
